### PR TITLE
Stylish, lint, and remove Either

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,70 @@
+# stylish-haskell configuration file
+# ==================================
+
+# The stylish-haskell tool is mainly configured by specifying steps. These steps
+# are a list, so they have an order, and one specific step may appear more than
+# once (if needed). Each file is processed by these steps in the given order.
+steps:
+  # Import cleanup
+  - imports:
+      # There are different ways we can align names and lists.
+      #
+      # - global: Align the import names and import list throughout the entire
+      #   file.
+      #
+      # - file: Like global, but don't add padding when there are no qualified
+      #   imports in the file.
+      #
+      # - group: Only align the imports per group (a group is formed by adjacent
+      #   import lines).
+      #
+      # - none: Do not perform any alignment.
+      #
+      # Default: global.
+      align: file
+
+  # Language pragmas
+  - language_pragmas:
+      # We can generate different styles of language pragma lists.
+      #
+      # - vertical: Vertical-spaced language pragmas, one per line.
+      #
+      # - compact: A more compact style.
+      #
+      # - compact_line: Similar to compact, but wrap each line with
+      #   `{-#LANGUAGE #-}'.
+      #
+      # Default: vertical.
+      style: vertical
+
+      # stylish-haskell can detect redundancy of some language pragmas. If this
+      # is set to true, it will remove those redundant pragmas. Default: true.
+      remove_redundant: true
+
+  # Align the types in record declarations
+  - records: {}
+
+  # Replace tabs by spaces. This is disabled by default.
+  # - tabs:
+  #     # Number of spaces to use for each tab. Default: 8, as specified by the
+  #     # Haskell report.
+  #     spaces: 8
+
+  # Remove trailing whitespace
+  - trailing_whitespace: {}
+
+# A common setting is the number of columns (parts of) code will be wrapped
+# to. Different steps take this into account. Default: 80.
+columns: 94
+
+# Sometimes, language extensions are specified in a cabal file or from the
+# command line instead of using language pragmas in the file. stylish-haskell
+# needs to be aware of these, so it can parse the file correctly.
+#
+# No language extensions are enabled by default.
+language_extensions:
+  - NoImplicitPrelude
+  - OverloadedStrings
+  - FlexibleContexts
+  - ConstraintKinds
+  - MultiParamTypeClasses

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
-language: haskell
-
 sudo: false
+
+language: c
+
+addons:
+  apt:
+    packages:
+    - libgmp-dev
 
 cache:
   directories:
@@ -9,13 +14,14 @@ cache:
 before_install:
   - mkdir -p ~/.local/bin
   - export PATH=~/.local/bin:$PATH
-  - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v0.1.3.1/stack-0.1.3.1-x86_64-linux.gz | gunzip > ~/.local/bin/stack
-  - chmod a+x ~/.local/bin/stack
+  - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
 install:
   - stack update
   - stack setup
-  - stack build --only-dependencies
+  - stack install hlint
+  - stack build skylark-core --only-dependencies
 
 script:
-  - stack build --test --bench
+  - ./lint.sh
+  - stack build skylark-core --test --bench

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+for dir in src test/Test
+do
+    hlint $dir
+done
+
+

--- a/src/Network/Skylark/Core/Conf.hs
+++ b/src/Network/Skylark/Core/Conf.hs
@@ -1,13 +1,10 @@
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 -- |
--- Module:      Network.Skylark.Core.Config
+-- Module:      Network.Skylark.Core.Conf
 -- Copyright:   (c) 2015 Mark Fine
 -- License:     BSD3
 -- Maintainer:  Mark Fine <mark@swift-nav.com>
 --
--- Config module for Skylark Core.
+-- Conf module for Skylark Core.
 
 module Network.Skylark.Core.Conf
   ( getCompleteConf
@@ -18,10 +15,10 @@ module Network.Skylark.Core.Conf
   ) where
 
 import Control.Monad.Logger
-import Data.Aeson
+import Data.Aeson                   hiding (decode)
 import Data.Default
 import Data.Word
-import Data.Yaml                    hiding (Parser)
+import Data.Yaml                    hiding (Parser, decode)
 import Network.Skylark.Core.Prelude
 import Network.Skylark.Core.Types
 import Options.Applicative
@@ -106,16 +103,10 @@ getDataFile f =
 -- configuration file, command line options, and the environmental
 -- configuration. Accepts the last non-Maybe value in each
 --
-getCompleteConf :: forall a. (Monoid a, FromEnv a, FromJSON a, Default a)
-                => ParserInfo a         -- ^ Command line parser for a type.
-                -> (a -> Maybe String)  -- ^ Accessor method for a
-                                        -- configuration file.
-                -> IO (Either String a) -- ^ Either an error string
-                                        -- or configuration.
+getCompleteConf :: (Monoid a, FromEnv a, Default a, FromJSON a) => ParserInfo a -> (a -> Maybe String) -> IO a
 getCompleteConf p conf = do
-  e <- decodeEnv :: IO (Either String a)
-  let rest x = do opt <- options p
-                  d <- def
-                  f <- getDataFile $ fromMaybe "" $ conf (d <> opt <> x)
-                  return $ Right (d <> f <> opt <> x)
-  either (return . Left) rest e
+  e <- decode
+  o <- options p
+  d <- def
+  f <- maybe (return Nothing) getDataFile $ conf $ d <> o <> fromMaybe mempty e
+  return $ d <> fromMaybe mempty f <> o <> fromMaybe mempty e

--- a/src/Network/Skylark/Core/Conf.hs
+++ b/src/Network/Skylark/Core/Conf.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE RankNTypes           #-}
-{-# LANGUAGE TemplateHaskell      #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- |
 -- Module:      Network.Skylark.Core.Config
@@ -22,7 +21,7 @@ import Control.Monad.Logger
 import Data.Aeson
 import Data.Default
 import Data.Word
-import Data.Yaml hiding (Parser)
+import Data.Yaml                    hiding (Parser)
 import Network.Skylark.Core.Prelude
 import Network.Skylark.Core.Types
 import Options.Applicative

--- a/src/Network/Skylark/Core/Maps.hs
+++ b/src/Network/Skylark/Core/Maps.hs
@@ -14,7 +14,7 @@ module Network.Skylark.Core.Maps
   ) where
 
 import           Control.Concurrent.STM
-import qualified Data.HashMap.Strict as M
+import qualified Data.HashMap.Strict          as M
 import           Network.Skylark.Core.Prelude
 import           Network.Skylark.Core.Types
 

--- a/src/Network/Skylark/Core/Trace.hs
+++ b/src/Network/Skylark/Core/Trace.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 
 -- |
 -- Module:      Network.Skylark.Core.Trace

--- a/src/Network/Skylark/Core/Types.hs
+++ b/src/Network/Skylark/Core/Types.hs
@@ -1,12 +1,12 @@
 {-# OPTIONS  -fno-warn-orphans          #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ConstraintKinds            #-}
+{-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE UndecidableInstances       #-}
 {-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 -- |
 -- Module:      Network.Skylark.Core.Types
@@ -18,26 +18,26 @@
 
 module Network.Skylark.Core.Types where
 
-import Control.Lens hiding ( (.=) )
+import Control.Lens                 hiding ((.=))
 import Control.Monad.Base
 import Control.Monad.Catch
 import Control.Monad.Logger
 import Control.Monad.Random
 import Control.Monad.Reader
-import Control.Monad.Trans.AWS hiding ( LogLevel )
+import Control.Monad.Trans.AWS      hiding (LogLevel)
 import Control.Monad.Trans.Resource
-import Data.Aeson hiding ( (.!=), (.=) )
+import Data.Aeson                   hiding ((.!=), (.=))
 import Data.Default
 import Data.Monoid
-import Data.Text ( pack, unpack )
-import Data.Text.Lazy ( toStrict )
-import Data.Text.Lazy.Builder hiding ( fromText )
+import Data.Text                    (pack, unpack)
+import Data.Text.Lazy               (toStrict)
+import Data.Text.Lazy.Builder       hiding (fromText)
 import Data.Time
 import Data.UUID
 import Network.AWS.DynamoDB
 import Network.Skylark.Core.Prelude
 import System.Envy
-import Text.Read ( readMaybe )
+import Text.Read                    (readMaybe)
 
 type Log = Loc -> LogSource -> LogLevel -> LogStr -> IO ()
 

--- a/src/Network/Skylark/Core/Upserts.hs
+++ b/src/Network/Skylark/Core/Upserts.hs
@@ -12,7 +12,7 @@ module Network.Skylark.Core.Upserts
   ) where
 
 import           Control.Lens
-import qualified Data.HashMap.Strict as M
+import qualified Data.HashMap.Strict          as M
 import           Network.AWS.DynamoDB
 import           Network.Skylark.Core.Prelude
 import           Network.Skylark.Core.Types

--- a/stylish.sh
+++ b/stylish.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+for dir in src test
+do
+    find $dir -name "*.hs" | xargs stylish-haskell -i
+done
+
+

--- a/test/Test/Network/Skylark/Core/Conf.hs
+++ b/test/Test/Network/Skylark/Core/Conf.hs
@@ -1,9 +1,8 @@
-{-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS  -fno-warn-orphans          #-}
 
 -- |
--- Module:      Test.Network.Skylark.Core.Config
+-- Module:      Test.Network.Skylark.Core.Conf
 -- Copyright:   (c) 2015 Mark Fine
 -- License:     BSD3
 -- Maintainer:  Mark Fine <mark@swift-nav.com>
@@ -15,7 +14,7 @@ module Test.Network.Skylark.Core.Conf
   ) where
 
 import BasicPrelude
-import Control.Lens hiding ((.=))
+import Control.Lens                   hiding ((.=))
 import Control.Monad.Logger
 import Data.Default
 import Network.Skylark.Core.Conf
@@ -26,6 +25,8 @@ import System.Envy
 import Test.Network.Skylark.Core.Test
 import Test.Tasty
 import Test.Tasty.HUnit
+
+{-# ANN module ("HLint: ignore Reduce duplication"::String) #-}
 
 parse :: [String] -> Maybe Conf
 parse = getParseResult . execParserPure (prefs idm) (parser parseConf)
@@ -96,10 +97,10 @@ testEnv :: TestTree
 testEnv =
   testGroup "Environmental configuration unit test"
     [ testCase "Empty configuration" $ do
-        unsetEnv "SKYLARK_CONFFILE"
+        unsetEnv "SKYLARK_CONF_FILE"
         unsetEnv "SKYLARK_PORT"
         unsetEnv "SKYLARK_TIMEOUT"
-        unsetEnv "SKYLARK_LOGLEVEL"
+        unsetEnv "SKYLARK_LOG_LEVEL"
         c <- decodeEnv :: IO (Either String Conf)
         c @?= Right Conf { _confFile     = Nothing
                          , _confPort     = Nothing
@@ -107,10 +108,10 @@ testEnv =
                          , _confLogLevel = Nothing
                          }
     , testCase "Port and Timeout" $ do
-        unsetEnv "SKYLARK_CONFFILE"
+        unsetEnv "SKYLARK_CONF_FILE"
         setEnv "SKYLARK_PORT" "1"
         setEnv "SKYLARK_TIMEOUT" "1"
-        unsetEnv "SKYLARK_LOGLEVEL"
+        unsetEnv "SKYLARK_LOG_LEVEL"
         c <- decodeEnv :: IO (Either String Conf)
         c @?= Right Conf { _confFile     = Nothing
                          , _confPort     = Just 1
@@ -118,10 +119,10 @@ testEnv =
                          , _confLogLevel = Nothing
                          }
      , testCase "String value" $ do
-        setEnv "SKYLARK_CONFFILE" "l"
+        setEnv "SKYLARK_CONF_FILE" "l"
         unsetEnv "SKYLARK_PORT"
         setEnv "SKYLARK_TIMEOUT" "1"
-        unsetEnv "SKYLARK_LOGLEVEL"
+        unsetEnv "SKYLARK_LOG_LEVEL"
         c <- decodeEnv :: IO (Either String Conf)
         c @?= Right Conf { _confFile     = Just "l"
                          , _confPort     = Nothing
@@ -129,10 +130,10 @@ testEnv =
                          , _confLogLevel = Nothing
                          }
      , testCase "LevelInfo" $ do
-        unsetEnv "SKYLARK_CONFFILE"
+        unsetEnv "SKYLARK_CONF_FILE"
         unsetEnv "SKYLARK_PORT"
         unsetEnv "SKYLARK_TIMEOUT"
-        setEnv "SKYLARK_LOGLEVEL" "info"
+        setEnv "SKYLARK_LOG_LEVEL" "info"
         c <- decodeEnv :: IO (Either String Conf)
         c @?= Right Conf { _confFile     = Nothing
                          , _confPort     = Nothing
@@ -140,10 +141,10 @@ testEnv =
                          , _confLogLevel = Just LevelInfo
                          }
      , testCase "LevelOther" $ do
-        unsetEnv "SKYLARK_CONFFILE"
+        unsetEnv "SKYLARK_CONF_FILE"
         unsetEnv "SKYLARK_PORT"
         unsetEnv "SKYLARK_TIMEOUT"
-        setEnv "SKYLARK_LOGLEVEL" "other"
+        setEnv "SKYLARK_LOG_LEVEL" "other"
         c <- decodeEnv :: IO (Either String Conf)
         c @?= Right Conf { _confFile     = Nothing
                          , _confPort     = Nothing
@@ -156,14 +157,14 @@ testDataFileFetch :: TestTree
 testDataFileFetch =
   testGroup "Testing reading of datafile"
     [ testCase "Existing test data file" $ do
-        c <- getDataFile "config/testing.yaml" :: IO Conf
+        c <- getDataFile "conf/testing.yaml" :: IO Conf
         c @?= Conf { _confFile     = Nothing
                    , _confPort     = Just 3031
                    , _confTimeout  = Just 121
                    , _confLogLevel = Just LevelDebug
                    }
     , testCase "Existing data file" $ do
-        c <- getDataFile "config/dev.yaml" :: IO Conf
+        c <- getDataFile "conf/dev.yaml" :: IO Conf
         c @?= Conf { _confFile     = Nothing
                    , _confPort     = Just 3030
                    , _confTimeout  = Just 120
@@ -202,22 +203,22 @@ testCompleteConf :: TestTree
 testCompleteConf =
   testGroup "Test parsing of a complete configuration"
     [ testCase "Sanity test on parsing of configuration" $ do
-        unsetEnv "SKYLARK_CONFFILE"
+        unsetEnv "SKYLARK_CONF_FILE"
         unsetEnv "SKYLARK_PORT"
         let p = parser parseConf
         c <- getCompleteConf p _confFile :: IO (Either String Conf)
-        either (flip assertBool False) ((@?=) $ def {_confPort = Just 3030}) c
+        either (`assertBool` False) ((@?=) $ def {_confPort = Just 3030}) c
     ]
 
 testCompleteConf1 :: TestTree
 testCompleteConf1 =
-  testGroup "Test parsing with env config"
+  testGroup "Test parsing with env configuration"
     [ testCase "Sanity test on parsing of configuration" $ do
-        unsetEnv "SKYLARK_CONFFILE"
+        unsetEnv "SKYLARK_CONF_FILE"
         setEnv "SKYLARK_PORT" "2222"
         let p = parser parseConf
         c <- getCompleteConf p _confFile :: IO (Either String Conf)
-        either (flip assertBool False) ((@?=) $ def {_confPort = Just 2222}) c
+        either (`assertBool` False) ((@?=) $ def {_confPort = Just 2222}) c
     ]
 
 tests :: TestTree

--- a/test/Test/Network/Skylark/Core/Conf.hs
+++ b/test/Test/Network/Skylark/Core/Conf.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# OPTIONS  -fno-warn-orphans          #-}
-
 -- |
 -- Module:      Test.Network.Skylark.Core.Conf
 -- Copyright:   (c) 2015 Mark Fine
@@ -101,75 +98,82 @@ testEnv =
         unsetEnv "SKYLARK_PORT"
         unsetEnv "SKYLARK_TIMEOUT"
         unsetEnv "SKYLARK_LOG_LEVEL"
-        c <- decodeEnv :: IO (Either String Conf)
-        c @?= Right Conf { _confFile     = Nothing
-                         , _confPort     = Nothing
-                         , _confTimeout  = Nothing
-                         , _confLogLevel = Nothing
-                         }
+        c <- decode
+        c @?= Just Conf
+          { _confFile     = Nothing
+          , _confPort     = Nothing
+          , _confTimeout  = Nothing
+          , _confLogLevel = Nothing
+          }
     , testCase "Port and Timeout" $ do
         unsetEnv "SKYLARK_CONF_FILE"
         setEnv "SKYLARK_PORT" "1"
         setEnv "SKYLARK_TIMEOUT" "1"
         unsetEnv "SKYLARK_LOG_LEVEL"
-        c <- decodeEnv :: IO (Either String Conf)
-        c @?= Right Conf { _confFile     = Nothing
-                         , _confPort     = Just 1
-                         , _confTimeout  = Just 1
-                         , _confLogLevel = Nothing
-                         }
+        c <- decode
+        c @?= Just Conf
+          { _confFile     = Nothing
+          , _confPort     = Just 1
+          , _confTimeout  = Just 1
+          , _confLogLevel = Nothing
+          }
      , testCase "String value" $ do
         setEnv "SKYLARK_CONF_FILE" "l"
         unsetEnv "SKYLARK_PORT"
         setEnv "SKYLARK_TIMEOUT" "1"
         unsetEnv "SKYLARK_LOG_LEVEL"
-        c <- decodeEnv :: IO (Either String Conf)
-        c @?= Right Conf { _confFile     = Just "l"
-                         , _confPort     = Nothing
-                         , _confTimeout  = Just 1
-                         , _confLogLevel = Nothing
-                         }
+        c <- decode
+        c @?= Just Conf
+          { _confFile     = Just "l"
+          , _confPort     = Nothing
+          , _confTimeout  = Just 1
+          , _confLogLevel = Nothing
+          }
      , testCase "LevelInfo" $ do
         unsetEnv "SKYLARK_CONF_FILE"
         unsetEnv "SKYLARK_PORT"
         unsetEnv "SKYLARK_TIMEOUT"
         setEnv "SKYLARK_LOG_LEVEL" "info"
-        c <- decodeEnv :: IO (Either String Conf)
-        c @?= Right Conf { _confFile     = Nothing
-                         , _confPort     = Nothing
-                         , _confTimeout  = Nothing
-                         , _confLogLevel = Just LevelInfo
-                         }
+        c <- decode
+        c @?= Just Conf
+          { _confFile     = Nothing
+          , _confPort     = Nothing
+          , _confTimeout  = Nothing
+          , _confLogLevel = Just LevelInfo
+          }
      , testCase "LevelOther" $ do
         unsetEnv "SKYLARK_CONF_FILE"
         unsetEnv "SKYLARK_PORT"
         unsetEnv "SKYLARK_TIMEOUT"
         setEnv "SKYLARK_LOG_LEVEL" "other"
-        c <- decodeEnv :: IO (Either String Conf)
-        c @?= Right Conf { _confFile     = Nothing
-                         , _confPort     = Nothing
-                         , _confTimeout  = Nothing
-                         , _confLogLevel = Just (LevelOther "other")
-                         }
+        c <- decode
+        c @?= Just Conf
+          { _confFile     = Nothing
+          , _confPort     = Nothing
+          , _confTimeout  = Nothing
+          , _confLogLevel = Just (LevelOther "other")
+          }
     ]
 
 testDataFileFetch :: TestTree
 testDataFileFetch =
   testGroup "Testing reading of datafile"
     [ testCase "Existing test data file" $ do
-        c <- getDataFile "conf/testing.yaml" :: IO Conf
-        c @?= Conf { _confFile     = Nothing
-                   , _confPort     = Just 3031
-                   , _confTimeout  = Just 121
-                   , _confLogLevel = Just LevelDebug
-                   }
+        c <- getDataFile "conf/testing.yaml"
+        c @?= Conf
+          { _confFile     = Nothing
+          , _confPort     = Just 3031
+          , _confTimeout  = Just 121
+          , _confLogLevel = Just LevelDebug
+          }
     , testCase "Existing data file" $ do
-        c <- getDataFile "conf/dev.yaml" :: IO Conf
-        c @?= Conf { _confFile     = Nothing
-                   , _confPort     = Just 3030
-                   , _confTimeout  = Just 120
-                   , _confLogLevel = Just LevelInfo
-                   }
+        c <- getDataFile "conf/dev.yaml"
+        c @?= Conf
+          { _confFile     = Nothing
+          , _confPort     = Just 3030
+          , _confTimeout  = Just 120
+          , _confLogLevel = Just LevelInfo
+          }
     ]
 
 testConfMonoid :: TestTree
@@ -180,53 +184,47 @@ testConfMonoid =
             b = a
         a <> b @?= a
     , testCase "Both a and b have one Just" $ do
-        let a = confTest { _confPort = Just 1 }
+        let a = confTest & confPort .~ Just 1
             b = a
         a <> b @?= a
     , testCase "b has a Just" $ do
         let a = confTest
-            b = a { _confPort = Just 1 }
+            b = a & confPort .~ Just 1
         a <> b @?= b
     , testCase "a has a Just" $ do
-        let a = confTest { _confPort = Just 1 }
-            b = a { _confPort = Nothing }
+        let a = confTest & confPort .~ Just 1
+            b = a & confPort .~ Nothing
         a <> b @?= a
     , testCase "Two separate Just fields are in the merged" $ do
-        let a = confTest { _confPort = Just 1 }
-            b = a { _confTimeout = Just 120 }
-        a <> b @?= a { _confTimeout = Just 120
-                     , _confPort    = Just 1
-                     }
+        let a = confTest & confPort .~ Just 1
+            b = a & confTimeout .~ Just 120
+        a <> b @?= b
+    , testCase "Empty conf is ignored" $ do
+        let a = confTest & confPort .~ Just 1
+            b = mempty
+        a <> b @?= a
+        b <> a @?= a
     ]
 
 testCompleteConf :: TestTree
 testCompleteConf =
   testGroup "Test parsing of a complete configuration"
-    [ testCase "Sanity test on parsing of configuration" $ do
+    [ testCase "Sanity test on parsing of configuration with defaults" $ do
         unsetEnv "SKYLARK_CONF_FILE"
         unsetEnv "SKYLARK_PORT"
-        let p = parser parseConf
-        c <- getCompleteConf p _confFile :: IO (Either String Conf)
-        either (`assertBool` False) ((@?=) $ def {_confPort = Just 3030}) c
-    ]
-
-testCompleteConf1 :: TestTree
-testCompleteConf1 =
-  testGroup "Test parsing with env configuration"
-    [ testCase "Sanity test on parsing of configuration" $ do
+        c <- getCompleteConf (parser parseConf) _confFile
+        c @?= (def & confPort .~ Just 3030)
+    , testCase "Sanity test on parsing of configuration with a non-default" $ do
         unsetEnv "SKYLARK_CONF_FILE"
         setEnv "SKYLARK_PORT" "2222"
-        let p = parser parseConf
-        c <- getCompleteConf p _confFile :: IO (Either String Conf)
-        either (`assertBool` False) ((@?=) $ def {_confPort = Just 2222}) c
+        c <- getCompleteConf (parser parseConf) _confFile
+        c @?= (def & confPort .~ Just 2222)
     ]
 
 tests :: TestTree
 tests =
   testGroup "Options tests"
     [ testGeneral
-    , testCompleteConf
-    , testCompleteConf1
     , testConfFile
     , testPort
     , testTimeout
@@ -234,4 +232,5 @@ tests =
     , testEnv
     , testDataFileFetch
     , testConfMonoid
+    , testCompleteConf
     ]


### PR DESCRIPTION
Brought in the stylish and linting stuff. I also moved `getCompleteConf` off of an `Either` type, and updated the tests.

Dealing with the `Either` is a pain - we should either (no pun intended) swallow or instead `throwIO`. Either option (again, no pun intended) is fine with me - and more leaning towards not crashing on bad env (though that could have surprising effects - but meh for now).

I love the conf as monoid! I changed both the failure to parse env and failure to have a conf file to return mempty, which should get ignored in the `<>`.

I also updated the tests to use lens vs. record syntax.

On an expected sad note - the env-related tests are racey and failing intermittently. We should probably comment them out so travis can pass consistently (is there a way to skip tests in HUnit?).

Great job Buro, this is a great abstraction for removing all the conf boilerplate!

/cc @mookerji 
