### PR TITLE
Refactorings around broker integration

### DIFF
--- a/test/Test/Network/Skylark/Core/Conf.hs
+++ b/test/Test/Network/Skylark/Core/Conf.hs
@@ -212,12 +212,12 @@ testCompleteConf =
     [ testCase "Sanity test on parsing of configuration with defaults" $ do
         unsetEnv "SKYLARK_CONF_FILE"
         unsetEnv "SKYLARK_PORT"
-        c <- getCompleteConf (parser parseConf) _confFile
+        c <- getConf parseConf
         c @?= (def & confPort .~ Just 3030)
     , testCase "Sanity test on parsing of configuration with a non-default" $ do
         unsetEnv "SKYLARK_CONF_FILE"
         setEnv "SKYLARK_PORT" "2222"
-        c <- getCompleteConf (parser parseConf) _confFile
+        c <- getConf parseConf
         c @?= (def & confPort .~ Just 2222)
     ]
 


### PR DESCRIPTION
+ have `getConf` take just a parser - it knows how to find the conf file if we put a `HasConf` typeclass on `a`.
+ move the trace level check into the fast logger function - this moves loglevel configuration out of the context.
+ move from `Word` back to `Int` - all the extra stuff around this doesn't feel worth it.
+ get rid of `ToEnv` - don't think we have any use for this.

/cc @mookerji 
