### PR TITLE
Fixes for broker

### DIFF
--- a/skylark-core.cabal
+++ b/skylark-core.cabal
@@ -23,7 +23,6 @@ library
                      , Network.Skylark.Core.Types
                      , Network.Skylark.Core.Upserts
   other-modules:       Network.Skylark.Core.Prelude
-                     , Paths_skylark_core
   ghc-options:         -Wall
   build-depends:       aeson
                      , amazonka
@@ -57,7 +56,8 @@ test-suite test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Test.hs
-  other-modules:       Test.Network.Skylark.Core.Conf
+  other-modules:       Paths_skylark_core
+                     , Test.Network.Skylark.Core.Conf
                      , Test.Network.Skylark.Core.Test
   build-depends:       base
                      , basic-prelude

--- a/src/Network/Skylark/Core.hs
+++ b/src/Network/Skylark/Core.hs
@@ -15,8 +15,9 @@ module Network.Skylark.Core
 import Control.Lens
 import Control.Monad.Logger
 import Control.Monad.Trans.AWS
+import Network.Skylark.Core.Prelude
 import Network.Skylark.Core.Types
 
 runCoreT :: HasCtx r => r -> CoreT r m a -> m a
 runCoreT e (CoreT m) =
-  runAWST e (runLoggingT m (e ^. ctxLog))
+  runAWST e $ runLoggingT m $ e ^. ctxLog

--- a/src/Network/Skylark/Core/Types.hs
+++ b/src/Network/Skylark/Core/Types.hs
@@ -242,7 +242,7 @@ instance HasConf Conf where
 
 instance Default Conf where
   def = Conf
-    { _confFile     = Just "conf/dev.yaml"
+    { _confFile     = Nothing
     , _confPort     = Just 5000
     , _confTimeout  = Just 120
     , _confLogLevel = Just LevelInfo

--- a/src/Network/Skylark/Core/Types.hs
+++ b/src/Network/Skylark/Core/Types.hs
@@ -242,7 +242,7 @@ instance HasConf Conf where
 
 instance Default Conf where
   def = Conf
-    { _confFile     = Nothing
+    { _confFile     = Just "conf/dev.yaml"
     , _confPort     = Just 5000
     , _confTimeout  = Just 120
     , _confLogLevel = Just LevelInfo

--- a/test/Test/Network/Skylark/Core/Conf.hs
+++ b/test/Test/Network/Skylark/Core/Conf.hs
@@ -17,6 +17,7 @@ import Data.Default
 import Network.Skylark.Core.Conf
 import Network.Skylark.Core.Types
 import Options.Applicative
+import Paths_skylark_core
 import System.Environment
 import System.Envy
 import Test.Network.Skylark.Core.Test
@@ -210,18 +211,18 @@ testConfMonoid =
 
 -- TOOD/FIX (Buro): This test occasionally fails because of a race
 -- condition in System.Environment.
-testCompleteConf :: TestTree
-testCompleteConf =
+testGetConf :: TestTree
+testGetConf =
   testGroup "Test parsing of a complete configuration"
     [ testCase "Sanity test on parsing of configuration with defaults" $ do
         unsetEnv "SKYLARK_CONF_FILE"
         unsetEnv "SKYLARK_PORT"
-        c <- getConf parseConf
+        c <- getConf parseConf getDataFileName
         c @?= (def & confPort .~ Just 3030)
     , testCase "Sanity test on parsing of configuration with a non-default" $ do
         unsetEnv "SKYLARK_CONF_FILE"
         setEnv "SKYLARK_PORT" "2222"
-        c <- getConf parseConf
+        c <- getConf parseConf getDataFileName
         c @?= (def & confPort .~ Just 2222)
     ]
 
@@ -236,5 +237,5 @@ tests =
     --, testEnv
     , testDataFileFetch
     , testConfMonoid
-    --, testCompleteConf
+    --, testGetConf
     ]


### PR DESCRIPTION
Couple of minor fixes based on testing. Namely, need to take file name resolver (`getDataFileName`) out of `getDataFile` - using core's paths means you can only find things in core's modules.

/cc @mookerji 