### PR TITLE
Let's uncensor these racey tests.

### DIFF
--- a/skylark-core.cabal
+++ b/skylark-core.cabal
@@ -73,11 +73,13 @@ test-suite test
                      , monad-logger
                      , optparse-applicative
                      , QuickCheck
+                     , quickcheck-instances
                      , skylark-core
                      , tasty
                      , tasty-hunit
+                     , tasty-quickcheck
                      , text
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
+  ghc-options:         -Wall
   default-language:    Haskell2010
   default-extensions:  NoImplicitPrelude
                        OverloadedStrings


### PR DESCRIPTION
- Removes threading from running Cabal tests, eliminating the race
  condition in the ENV options test.
- QuickCheck test for environmental setting and options reading.

/cc @mfine @JoshuaGross