### PR TITLE
Retries module

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "Building Skylark Core"
+stack build skylark-core "$@"
+

--- a/skylark-core.cabal
+++ b/skylark-core.cabal
@@ -21,6 +21,7 @@ library
                      , Network.Skylark.Core.Constants
                      , Network.Skylark.Core.Maps
                      , Network.Skylark.Core.Prelude
+                     , Network.Skylark.Core.Retries
                      , Network.Skylark.Core.Setup
                      , Network.Skylark.Core.Timers
                      , Network.Skylark.Core.Trace
@@ -66,12 +67,14 @@ test-suite test
   main-is:             Test.hs
   other-modules:       Paths_skylark_core
                      , Test.Network.Skylark.Core.Conf
+                     , Test.Network.Skylark.Core.Retries
                      , Test.Network.Skylark.Core.Setup
                      , Test.Network.Skylark.Core.Test
   build-depends:       base
                      , basic-prelude
                      , data-default
                      , envy
+                     , exceptions
                      , lens
                      , monad-logger
                      , optparse-applicative

--- a/src/Network/Skylark/Core/Constants.hs
+++ b/src/Network/Skylark/Core/Constants.hs
@@ -16,8 +16,5 @@ awsAccessKey = "AWS_ACCESS_KEY_ID"
 awsSecretKey :: Text
 awsSecretKey = "AWS_SECRET_ACCESS_KEY"
 
-jitterRate :: Double
-jitterRate = 0.15
-
 infoFile :: String
 infoFile = "conf/info.yaml"

--- a/src/Network/Skylark/Core/Retries.hs
+++ b/src/Network/Skylark/Core/Retries.hs
@@ -1,0 +1,159 @@
+-- |
+-- Module:      Network.Skylark.Core.Retries
+-- Copyright:   (c) 2015 Mark Fine
+-- License:     BSD3
+-- Maintainer:  Mark Fine <mark@swift-nav.com>
+--
+-- Retries module for Skylark Core. Based on retry package.
+
+module Network.Skylark.Core.Retries
+  ( retry
+  , recover
+  , recoverAll
+  , constant
+  , fixedDelay
+  , exponentialBackoff
+  , jitter
+  , maxCount
+  , maxDelay
+  , maxTotal
+  , fullJitter
+  , equalJitter
+  , decorrelatedJitter
+  ) where
+
+import Control.Concurrent
+import Control.Lens
+import Control.Monad.Catch
+import Control.Monad.Random
+import Data.Default
+import Network.Skylark.Core.Prelude hiding (catch)
+import Network.Skylark.Core.Types
+
+-- | Update retry state, setting delay from policy and incrementing count.
+--
+update :: MonadIO m => RetryPolicy -> RetryState -> m RetryState
+update policy state = do
+  delay <- liftIO $ runRetryPolicy policy state
+  return $ state &
+    rsCount +~ 1 &
+    rsDelay .~ delay &
+    rsTotal +~ fromMaybe 0 delay
+
+-- | Apply retry state, update and sleep if necessary.
+--
+apply :: MonadIO m => RetryPolicy -> RetryState -> m RetryState
+apply policy state = do
+  state' <- update policy state
+  maybe (return ()) (liftIO . threadDelay . fromIntegral) $ state' ^. rsDelay
+  return state'
+
+-- | Retry an action with a policy and a check routine.
+--
+retry :: MonadIO m => RetryPolicy -> (a -> m Bool) -> m a -> m a
+retry policy check action =
+  loop def where
+    loop state = do
+      result <- action
+      again <- check result
+      state' <- apply policy state
+      if not again || isNothing (state' ^. rsDelay) then return result else loop state'
+
+-- | Recover exceptions from an action with a policy and a check exception routine.
+--
+recover :: (MonadIO m, MonadCatch m, Exception e) => RetryPolicy -> (e -> m Bool) -> m a -> m a
+recover policy check action =
+  loop def where
+    loop state =
+      catch action $ \e -> do
+        again <- maybe (throwM e) check (fromException e)
+        state' <- apply policy state
+        if not again || isNothing (state' ^. rsDelay) then throwM e else loop state'
+
+-- | Recover all exceptions.
+--
+recoverAll :: (MonadIO m, MonadCatch m) => RetryPolicy -> (SomeException -> m Bool) -> m a -> m a
+recoverAll = recover
+
+-- | Constant policy.
+--
+constant :: RetryPolicy
+constant = RetryPolicy $ \state ->
+  return $ state ^. rsDelay
+
+-- | Fixed delay policy.
+--
+fixedDelay :: Word -> RetryPolicy
+fixedDelay delay = RetryPolicy $ \_state ->
+  return $ Just delay
+
+-- | Exponential backoff policy.
+--
+exponentialBackoff :: Word -> RetryPolicy
+exponentialBackoff base = RetryPolicy $ \state ->
+  return $ Just $ base * 2 ^ (state ^. rsCount)
+
+-- | Jitter delay policy.
+--
+jitter :: RetryPolicy -> RetryPolicy
+jitter policy = RetryPolicy $ \state -> do
+  state' <- update policy state
+  maybe' (state' ^. rsDelay) (return Nothing) $ \delay -> do
+    delay' <- getRandomR (delay - div delay 10, delay + div delay 10)
+    return $ Just delay'
+
+-- | Max count policy.
+--
+maxCount :: Word -> RetryPolicy -> RetryPolicy
+maxCount count policy = RetryPolicy $ \state -> do
+  state' <- update policy state
+  return $ if state' ^. rsCount >= count then Nothing else state' ^. rsDelay
+
+-- | Max delay policy.
+--
+maxDelay :: Word -> RetryPolicy -> RetryPolicy
+maxDelay delay policy = RetryPolicy $ \state -> do
+  state' <- update policy state
+  return $ min delay <$> state' ^. rsDelay
+
+-- | Max total delay policy.
+--
+maxTotal :: Word -> RetryPolicy -> RetryPolicy
+maxTotal total policy = RetryPolicy $ \state -> do
+  state' <- update policy state
+  return $ if state' ^. rsTotal >= total then Nothing else state' ^. rsDelay
+
+-- | Full Jitter policy.
+--
+-- @http:\/\/www.awsarchitectureblog.com\/2015\/03\/backoff.html@
+--
+-- sleep = random_between(0, min(cap, base * 2 ** attempt))
+--
+fullJitter :: Word -> RetryPolicy
+fullJitter base = RetryPolicy $ \state -> do
+  delay <- getRandomR (0, base * 2 ^ (state ^. rsCount))
+  return $ Just delay
+
+-- | Equal Jitter policy.
+--
+-- @http:\/\/www.awsarchitectureblog.com\/2015\/03\/backoff.html@
+--
+-- temp = min(cap, base * 2 ** attempt)
+-- sleep = temp / 2 + random_between(0, temp / 2)
+--
+equalJitter :: Word -> RetryPolicy
+equalJitter base = RetryPolicy $ \state -> do
+  let temp = base * 2 ^ (state ^. rsCount)
+  delay <- getRandomR (0, div temp 2)
+  return $ Just $ div temp 2 + delay
+
+-- | Decorrelated Jitter policy.
+--
+-- @http:\/\/www.awsarchitectureblog.com\/2015\/03\/backoff.html@
+--
+-- sleep = min(cap, random_between(base, sleep * 3))
+--
+decorrelatedJitter :: Word -> RetryPolicy
+decorrelatedJitter base = RetryPolicy $ \state -> do
+  delay' <- getRandomR (base, max base (fromMaybe base (state ^. rsDelay)) * 3)
+  return $ Just delay'

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -7,13 +7,15 @@
 -- Test module for Skylark Core.
 
 import           BasicPrelude
-import qualified Test.Network.Skylark.Core.Conf  as Conf
-import qualified Test.Network.Skylark.Core.Setup as Setup
+import qualified Test.Network.Skylark.Core.Conf    as Conf
+import qualified Test.Network.Skylark.Core.Retries as Retries
+import qualified Test.Network.Skylark.Core.Setup   as Setup
 import           Test.Tasty
 
 tests :: TestTree
 tests = testGroup "Tests"
   [ Conf.tests
+  , Retries.tests
   , Setup.tests
   ]
 

--- a/test/Test/Network/Skylark/Core/Retries.hs
+++ b/test/Test/Network/Skylark/Core/Retries.hs
@@ -1,0 +1,181 @@
+{-# OPTIONS -fno-warn-orphans #-}
+
+-- |
+-- Module:      Test.Network.Skylark.Core.Retries
+-- Copyright:   (c) 2015 Mark Fine
+-- License:     BSD3
+-- Maintainer:  Mark Fine <mark@swift-nav.com>
+--
+-- Test retries module for Skylark Core.
+
+module Test.Network.Skylark.Core.Retries
+  ( tests
+  ) where
+
+import Control.Lens                 hiding (pre)
+import Control.Monad.Catch
+import Data.IORef
+import Network.Skylark.Core.Prelude
+import Network.Skylark.Core.Retries
+import Network.Skylark.Core.Types
+import Test.QuickCheck.Monadic
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+instance Arbitrary RetryState where
+  arbitrary = RetryState <$> arbitrary <*> arbitrary <*> arbitrary
+
+limits :: Ord a => Maybe a -> a -> a -> Bool
+limits delay lo hi =
+  maybe' delay False $ \delay' ->
+    delay' >= lo && delay' <= hi
+
+testPolicies :: TestTree
+testPolicies =
+  testGroup "Policy tests"
+    [ testProperty "Constant" $
+        \delay state -> monadicIO $ do
+          delay' <- run $ runRetryPolicy constant $ state & rsDelay .~ delay
+          assert $ delay' == delay
+    , testProperty "Fixed delay" $
+        \delay state -> monadicIO $ do
+          delay' <- run $ runRetryPolicy (fixedDelay delay) state
+          assert $ delay' == Just delay
+    , testProperty "Exponential backoff" $
+        \base count state -> monadicIO $ do
+          delay <- run $ runRetryPolicy (exponentialBackoff base) $ state & rsCount .~ count
+          let temp = base * 2 ^ count
+          assert $ maybe' delay False (== temp)
+    , testProperty "Full jitter" $
+        \base count state -> monadicIO $ do
+          delay <- run $ runRetryPolicy (fullJitter base) $ state & rsCount .~ count
+          let temp = base * 2 ^ count
+          assert $ limits delay 0 temp
+    , testProperty "Equal jitter" $
+        \base count state -> monadicIO $ do
+          delay <- run $ runRetryPolicy (equalJitter base) $ state & rsCount .~ count
+          let temp = base * 2 ^ count
+          assert $ limits delay (div temp 2) temp
+    , testProperty "Decorrelated jitter" $
+        \base delay state -> monadicIO $ do
+          delay' <- run $ runRetryPolicy (decorrelatedJitter base) $ state & rsDelay .~ Just delay
+          let temp = max base delay * 3
+          assert $ limits delay' base temp
+    , testProperty "Decorrelated jitter (no delay)" $
+        \base state -> monadicIO $ do
+          delay' <- run $ runRetryPolicy (decorrelatedJitter base) $ state & rsDelay .~ Nothing
+          let temp = base * 3
+          assert $ limits delay' base temp
+    ]
+
+testPolicyModifiers :: TestTree
+testPolicyModifiers =
+  testGroup "Policy modifier tests"
+    [ testProperty "Jitter" $
+        \delay state -> monadicIO $ do
+          delay' <- run $ runRetryPolicy (jitter constant) $ state & rsDelay .~ Just delay
+          let temp = div delay 10
+          assert $ limits delay' (delay - temp) (delay + temp)
+    , testProperty "Jitter (no delay)" $
+        \state -> monadicIO $ do
+          delay <- run $ runRetryPolicy (jitter constant) $ state & rsDelay .~ Nothing
+          assert $ isNothing delay
+    , testProperty "Max count" $
+        \delay count limit state -> monadicIO $ do
+          delay' <- run $ runRetryPolicy (maxCount limit constant) $ state &
+            rsCount .~ count &
+            rsDelay .~ delay
+          assert $ if count + 1 >= limit then isNothing delay' else delay' == delay
+   , testProperty "Max delay" $
+       \delay limit state -> monadicIO $ do
+         delay' <- run $ runRetryPolicy (maxDelay limit constant) $ state & rsDelay .~ Just delay
+         assert $ maybe' delay' False $ \delay'' -> delay'' == delay || delay'' == limit
+   , testProperty "Max delay (no delay)" $
+       \limit state -> monadicIO $ do
+         delay <- run $ runRetryPolicy (maxDelay limit constant) $ state & rsDelay .~ Nothing
+         assert $ isNothing delay
+   , testProperty "Max total" $
+       \delay total limit state -> monadicIO $ do
+         delay' <- run $ runRetryPolicy (maxTotal limit constant) $ state &
+           rsDelay .~ Just delay &
+           rsTotal .~ total
+         assert $ if total + delay >= limit then isNothing delay' else delay' == Just delay
+   , testProperty "Max total (no delay)" $
+       \total limit state -> monadicIO $ do
+         delay <- run $ runRetryPolicy (maxTotal limit constant) $ state &
+           rsDelay .~ Nothing &
+           rsTotal .~ total
+         assert $ isNothing delay
+    ]
+
+countAction :: (IORef (Small Word) -> IO ()) -> IO (Small Word)
+countAction action = do
+  counter <- newIORef 0
+  action counter
+  readIORef counter
+
+countRetry :: Bool -> Small Word -> PropertyM IO (Small Word)
+countRetry again count = do
+  pre $ count > 0
+  run $ countAction $ \counter ->
+    retry (maxCount (getSmall count) $ fixedDelay 0)
+      (const $ return again) $
+      modifyIORef' counter (+ 1)
+
+testRetry :: TestTree
+testRetry =
+  testGroup "Retry tests"
+    [ testProperty "Again" $
+        \count -> monadicIO $ do
+          counter <- countRetry True count
+          assert $ counter == count
+    , testProperty "Not again" $
+        \count -> monadicIO $ do
+          counter <- countRetry False count
+          assert $ counter == 1
+    ]
+
+recoverAllAction :: Bool -> Small Word -> IO () -> IORef (Small Word) -> IO ()
+recoverAllAction again count action counter =
+  recoverAll (maxCount (getSmall count) $ fixedDelay 0)
+    (const $ return again) $ do
+      modifyIORef' counter (+ 1)
+      action
+
+countRecoverAll :: Bool -> Small Word -> IO () -> PropertyM IO (Small Word)
+countRecoverAll again count action = do
+  pre $ count > 0
+  run $ countAction $
+    recoverAllAction again count action
+
+countRecoverAll' :: Bool -> Small Word -> IO () -> PropertyM IO (Small Word)
+countRecoverAll' again count action = do
+  pre $ count > 0
+  run $ countAction $
+    handleAll (const $ return ()) . recoverAllAction again count action
+
+testRecoverAll :: TestTree
+testRecoverAll =
+  testGroup "Recover All tests"
+    [ testProperty "No exception" $
+        \count -> monadicIO $ do
+          counter <- countRecoverAll True count $ return ()
+          assert $ counter == 1
+    , testProperty "Exception again" $
+        \count -> monadicIO $ do
+          counter <- countRecoverAll' True count $ throwM $ userError "omg"
+          assert $ counter == count
+    , testProperty "Exception not again" $
+        \count -> monadicIO $ do
+          counter <- countRecoverAll' False count $ throwM $ userError "omg"
+          assert $ counter == 1
+    ]
+
+tests :: TestTree
+tests =
+  testGroup "Retries tests"
+    [ testPolicies
+    , testPolicyModifiers
+    , testRetry
+    , testRecoverAll
+    ]


### PR DESCRIPTION
Stripped down and simplified retries from the `retry` package.

Wanted to use new jitter retry policy stuff that came in with `retry-0.7`, but that would mean rev'ing amazonka and wanted to avoid that (though probably not a big deal). Boiled down the retry functionality into its essence and cleaned it up and brought some more jitter functionality from the referenced AWS blog.

/cc @mookerji 