### PR TITLE
Retries with timestamps

### DIFF
--- a/skylark-core.cabal
+++ b/skylark-core.cabal
@@ -90,6 +90,7 @@ test-suite test
                      , tasty-hunit
                      , tasty-quickcheck
                      , text
+                     , time
   ghc-options:         -Wall
   default-language:    Haskell2010
   default-extensions:  NoImplicitPrelude

--- a/src/Network/Skylark/Core/Types.hs
+++ b/src/Network/Skylark/Core/Types.hs
@@ -350,6 +350,8 @@ data RetryState = RetryState
   { _rsCount :: Word
   , _rsDelay :: Maybe Word
   , _rsTotal :: Word
+  , _rsStart :: Maybe UTCTime
+  , _rsLast  :: Maybe UTCTime
   } deriving ( Eq, Show )
 
 $(makeLenses ''RetryState)
@@ -359,6 +361,8 @@ instance Default RetryState where
     { _rsCount = 0
     , _rsDelay = Nothing
     , _rsTotal = 0
+    , _rsStart = Nothing
+    , _rsLast  = Nothing
     }
 
 newtype RetryPolicy = RetryPolicy

--- a/test/Test/Network/Skylark/Core/Retries.hs
+++ b/test/Test/Network/Skylark/Core/Retries.hs
@@ -15,12 +15,21 @@ module Test.Network.Skylark.Core.Retries
 import Control.Lens                 hiding (pre)
 import Control.Monad.Catch
 import Data.IORef
+import Data.Time
 import Network.Skylark.Core.Prelude
 import Network.Skylark.Core.Retries
 import Network.Skylark.Core.Types
 import Test.QuickCheck.Monadic
 import Test.Tasty
 import Test.Tasty.QuickCheck
+
+instance Arbitrary UTCTime where
+  arbitrary = do
+    randomDay   <- choose (1, 29)      :: Gen Int
+    randomMonth <- choose (1, 12)      :: Gen Int
+    randomYear  <- choose (1970, 2015) :: Gen Integer
+    randomTime  <- choose (0, 86401)   :: Gen Int
+    return $ UTCTime (fromGregorian randomYear randomMonth randomDay) (fromIntegral randomTime)
 
 instance Arbitrary RetryState where
   arbitrary = RetryState <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary

--- a/test/Test/Network/Skylark/Core/Retries.hs
+++ b/test/Test/Network/Skylark/Core/Retries.hs
@@ -23,7 +23,7 @@ import Test.Tasty
 import Test.Tasty.QuickCheck
 
 instance Arbitrary RetryState where
-  arbitrary = RetryState <$> arbitrary <*> arbitrary <*> arbitrary
+  arbitrary = RetryState <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
 limits :: Ord a => Maybe a -> a -> a -> Bool
 limits delay lo hi =


### PR DESCRIPTION
Put start and last timestamps into `RetryState`. Idea would be to use this for a) total duration limits, and b) adjustments based on last known timestamp.