### PR TITLE
--metrics flag

### DIFF
--- a/src/Network/Skylark/Core/Conf.hs
+++ b/src/Network/Skylark/Core/Conf.hs
@@ -83,6 +83,14 @@ appName =
       <> metavar "APP-NAME"
       <> help    "Application name"
 
+-- | Metrics collection.
+--
+metrics :: Parser Bool
+metrics =
+  switch
+    $  long "metrics"
+    <> help "Metrics Collection"
+
 -- | Configuration parser.
 --
 parseConf :: Parser Conf
@@ -91,7 +99,8 @@ parseConf = Conf    <$>
   optional port     <*>
   optional timeout  <*>
   optional logLevel <*>
-  optional appName
+  optional appName  <*>
+  optional metrics
 
 -- | Produce a full command line options parser.
 --

--- a/src/Network/Skylark/Core/Trace.hs
+++ b/src/Network/Skylark/Core/Trace.hs
@@ -124,13 +124,18 @@ traceEvent :: (Num t, MonadCore e m)
            -> t                  -- ^ Any numeric value
            -> m ()
 traceEvent metricType key value = do
-  group' <- getEventGroup
-  trace logInfoN $ sformat ("event=metric : " % stext) (txt $ metricType group' key value)
+  metrics <- view confMetrics
+  when (fromMaybe False metrics) $ do
+    group' <- getEventGroup
+    trace logInfoN $ sformat ("event=metric : " % stext) (txt $ metricType group' key value)
 
 -- | Emit a single metric event to the log.
 --
 traceMetric :: MonadCore e m => Metric -> m ()
-traceMetric metric = trace logInfoN $ sformat ("event=metric : " % stext) (txt metric)
+traceMetric metric = do
+  metrics <- view confMetrics
+  when (fromMaybe False metrics) $
+    trace logInfoN $ sformat ("event=metric : " % stext) (txt metric)
 
 -- | Emit a key-value counter.
 --

--- a/src/Network/Skylark/Core/Types.hs
+++ b/src/Network/Skylark/Core/Types.hs
@@ -74,6 +74,7 @@ data Conf = Conf
   , _confTimeout  :: Maybe Int      -- ^ Connection timeout (sec)
   , _confLogLevel :: Maybe LogLevel -- ^ Logging level
   , _confAppName  :: Maybe Text     -- ^ Name of the application
+  , _confMetrics  :: Maybe Bool     -- ^ Enable metrics collection
   } deriving ( Eq, Show )
 
 $(makeClassy ''Conf)
@@ -98,6 +99,7 @@ instance Default Conf where
     , _confTimeout  = Just 120
     , _confLogLevel = Just LevelInfo
     , _confAppName  = Nothing
+    , _confMetrics  = Nothing
     }
 
 instance FromJSON Conf where
@@ -107,7 +109,8 @@ instance FromJSON Conf where
       v .:? "port"      <*>
       v .:? "timeout"   <*>
       v .:? "log-level" <*>
-      v .:? "app-name"
+      v .:? "app-name"  <*>
+      v .:? "metrics"
   parseJSON _ = mzero
 
 instance FromEnv Conf where
@@ -117,7 +120,8 @@ instance FromEnv Conf where
       envMaybe "SKYLARK_PORT"      <*>
       envMaybe "SKYLARK_TIMEOUT"   <*>
       envMaybe "SKYLARK_LOG_LEVEL" <*>
-      envMaybe "SKYLARK_APP_NAME"
+      envMaybe "SKYLARK_APP_NAME"  <*>
+      envMaybe "SKYLARK_METRICS"
 
 instance Monoid Conf where
   mempty = Conf
@@ -126,6 +130,7 @@ instance Monoid Conf where
     , _confTimeout  = Nothing
     , _confLogLevel = Nothing
     , _confAppName  = Nothing
+    , _confMetrics  = Nothing
     }
 
   mappend a b = Conf
@@ -134,6 +139,7 @@ instance Monoid Conf where
     , _confTimeout  = merge _confTimeout a b
     , _confLogLevel = merge _confLogLevel a b
     , _confAppName  = merge _confAppName a b
+    , _confMetrics  = merge _confMetrics a b
     }
 
 -- | Given a record field accessor. return the second non-Nothing


### PR DESCRIPTION
Save our consoles: add a `--metrics` flag. This exposes a global metrics flag, then uses it to turn off metric outputting.

There's likely to be more flags, could have a separate flag structure, but will start with this for now.

/cc @mookerji 