### PR TITLE
Fix haddock parse error

### DIFF
--- a/src/Network/Skylark/Core/Time.hs
+++ b/src/Network/Skylark/Core/Time.hs
@@ -20,7 +20,7 @@
 module Network.Skylark.Core.Time
   (
   -- * Formats
-  ISO8601 (..)
+    ISO8601 (..)
   -- * Helpers
   , IsUTCTime
   , toUtcTime

--- a/src/Network/Skylark/Core/Time.hs
+++ b/src/Network/Skylark/Core/Time.hs
@@ -18,16 +18,17 @@
 --  per `Format` type, for slightly more flexible parsing.
 
 module Network.Skylark.Core.Time
-    -- * Formats
-    ( ISO8601 (..)
-    -- * Helpers
-    , IsUTCTime
-    , toUtcTime
-    , parseTime
-    , renderFormattedTime
-    -- * Re-export Data.Time
-    , module Data.Time
-    ) where
+  (
+  -- * Formats
+  ISO8601 (..)
+  -- * Helpers
+  , IsUTCTime
+  , toUtcTime
+  , parseTime
+  , renderFormattedTime
+  -- * Re-export Data.Time
+  , module Data.Time
+  ) where
 
 import Data.Aeson
 import Data.Data                    (Data)


### PR DESCRIPTION
`stack haddock` was failing on a failed comment parse.  The fix was to move the comment into the parens of the module export list.