### PR TITLE
Injectable clock

### DIFF
--- a/src/Network/Skylark/Core/Setup.hs
+++ b/src/Network/Skylark/Core/Setup.hs
@@ -51,10 +51,11 @@ newCtx c tag = do
   let _ctxConf     = c
       _ctxPreamble = preamble name
       _ctxSettings = newSettings port timeout
+      _ctxClock    = getCurrentTime
   logLevel  <- mandatory "log-level" $ c ^. confLogLevel
   _ctxEnv   <- newEnv Oregon $ FromEnv awsAccessKey awsSecretKey Nothing
   _ctxLog   <- newStderrTrace logLevel
-  _ctxStart <- getCurrentTime
+  _ctxStart <- _ctxClock
   return Ctx {..} where
     preamble name =
       sformat ("n=" % stext % " t=" % stext) name tag

--- a/src/Network/Skylark/Core/Trace.hs
+++ b/src/Network/Skylark/Core/Trace.hs
@@ -59,8 +59,8 @@ traceNull _loc _source _level _s =
 
 trace :: MonadCore e m => (Text -> m ()) -> Text -> m ()
 trace logN s = do
-  clock  <- view ctxClock
-  time <- liftIO clock
+  clock    <- view ctxClock
+  time     <- liftIO clock
   preamble <- view ctxPreamble
   logN $ sformat (stext % " " % stext % " " % stext % "\n")
     (txt time) preamble s

--- a/src/Network/Skylark/Core/Trace.hs
+++ b/src/Network/Skylark/Core/Trace.hs
@@ -15,13 +15,9 @@ module Network.Skylark.Core.Trace
   , newStdoutTrace
   , traceNull
   , traceDebug
-  , traceDebug'
   , traceInfo
-  , traceInfo'
   , traceWarn
-  , traceWarn'
   , traceError
-  , traceError'
   , traceMetric
   , traceEventCounter
   , traceEventTimer
@@ -31,7 +27,6 @@ module Network.Skylark.Core.Trace
 
 import Control.Lens
 import Control.Monad.Logger
-import Data.Time
 import Formatting
 import Network.Skylark.Core.Conf
 import Network.Skylark.Core.Prelude
@@ -64,40 +59,23 @@ traceNull _loc _source _level _s =
 
 trace :: MonadCore e m => (Text -> m ()) -> Text -> m ()
 trace logN s = do
-  time <- liftIO getCurrentTime
+  clock  <- view ctxClock
+  time <- liftIO clock
   preamble <- view ctxPreamble
   logN $ sformat (stext % " " % stext % " " % stext % "\n")
     (txt time) preamble s
 
-trace' :: MonadIO m => (Text -> m b) -> Text -> m b
-trace' logN s = do
-  time <- liftIO getCurrentTime
-  logN $ sformat (stext % " " % stext % "\n")
-    (txt time) s
-
 traceDebug :: MonadCore e m => Text -> m ()
 traceDebug = trace logDebugN
-
-traceDebug' :: Text -> IO ()
-traceDebug' s = newStderrTrace LevelDebug >>= runLoggingT (trace' logDebugN s)
 
 traceInfo :: MonadCore e m => Text -> m ()
 traceInfo = trace logInfoN
 
-traceInfo' :: Text -> IO ()
-traceInfo' s = newStderrTrace LevelInfo >>= runLoggingT (trace' logInfoN s)
-
 traceWarn :: MonadCore e m => Text -> m ()
 traceWarn = trace logWarnN
 
-traceWarn' :: Text -> IO ()
-traceWarn' s = newStderrTrace LevelWarn >>= runLoggingT (trace' logWarnN s)
-
 traceError :: MonadCore e m => Text -> m ()
 traceError = trace logErrorN
-
-traceError' :: Text -> IO ()
-traceError' s = newStderrTrace LevelError >>= runLoggingT (trace' logErrorN s)
 
 --------------------------------------------------------------------------------
 -- Event logging: emit metrics to the application log.

--- a/src/Network/Skylark/Core/Types.hs
+++ b/src/Network/Skylark/Core/Types.hs
@@ -173,8 +173,8 @@ data Ctx = Ctx
   , _ctxLog      :: Log
   , _ctxPreamble :: Text
   , _ctxSettings :: Settings
-  , _ctxStart    :: UTCTime
   , _ctxClock    :: IO UTCTime
+  , _ctxStart    :: UTCTime
   }
 
 $(makeClassyConstraints ''Ctx [''HasConf, ''HasEnv])

--- a/src/Network/Skylark/Core/Types.hs
+++ b/src/Network/Skylark/Core/Types.hs
@@ -41,7 +41,6 @@ import           Data.Text.Lazy.Builder       hiding (fromText)
 import           Data.Time
 import           Data.UUID
 import qualified Data.UUID                    as UUID
-import qualified Data.UUID.Types.Internal     as UUID
 import           Network.AWS.DynamoDB
 import           Network.HTTP.Types
 import           Network.Skylark.Core.Lens.TH
@@ -175,6 +174,7 @@ data Ctx = Ctx
   , _ctxPreamble :: Text
   , _ctxSettings :: Settings
   , _ctxStart    :: UTCTime
+  , _ctxClock    :: IO UTCTime
   }
 
 $(makeClassyConstraints ''Ctx [''HasConf, ''HasEnv])

--- a/test/Test/Network/Skylark/Core/DynamoDB.hs
+++ b/test/Test/Network/Skylark/Core/DynamoDB.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE ConstraintKinds           #-}
-{-# LANGUAGE DeriveGeneric             #-}
-{-# LANGUAGE TemplateHaskell           #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DeriveGeneric   #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS  -fno-warn-orphans         #-}
 {-# OPTIONS  -fno-warn-unused-binds    #-}
 {-# OPTIONS  -fno-warn-unused-matches  #-}
@@ -20,11 +20,11 @@ module Test.Network.Skylark.Core.DynamoDB
 
 import           Control.Lens
 import           Data.Aeson
-import qualified Data.ByteString.Lazy           as LBS
+import qualified Data.ByteString.Lazy          as LBS
 import           Data.Derive.Arbitrary
 import           Data.DeriveTH
-import qualified Data.HashMap.Strict            as M
-import qualified Data.Text                      as T
+import qualified Data.HashMap.Strict           as M
+import qualified Data.Text                     as T
 import           GHC.Generics
 import           Network.AWS.DynamoDB
 import           Network.Skylark.Core.DynamoDB


### PR DESCRIPTION
Don't call `getCurrentTime` directly - use the `ctxClock`.

/cc @swift-nav/skylark